### PR TITLE
V1 miniedit fix 2913

### DIFF
--- a/Terminal.Gui/Core/Responder.cs
+++ b/Terminal.Gui/Core/Responder.cs
@@ -15,7 +15,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 
 namespace Terminal.Gui {
@@ -255,7 +255,7 @@ namespace Terminal.Gui {
 			}
 			return m.GetBaseDefinition ().DeclaringType != m.DeclaringType;
 		}
-		
+
 		/// <summary>
 		/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
 		/// </summary>
@@ -277,9 +277,6 @@ namespace Terminal.Gui {
 
 				// TODO: free unmanaged resources (unmanaged objects) and override finalizer
 				// TODO: set large fields to null
-#if DEBUG_IDISPOSABLE
-				Instances.Remove(this);
-#endif
 				disposedValue = true;
 			}
 		}
@@ -294,6 +291,10 @@ namespace Terminal.Gui {
 			GC.SuppressFinalize (this);
 #if DEBUG_IDISPOSABLE
 			WasDisposed = true;
+
+			foreach (var instance in Instances.Where (x => x.WasDisposed).ToList ()) {
+				Instances.Remove (instance);
+			}
 #endif
 		}
 	}

--- a/UnitTests/Application/ApplicationTests.cs
+++ b/UnitTests/Application/ApplicationTests.cs
@@ -91,8 +91,7 @@ namespace Terminal.Gui.ApplicationTests {
 			Application.Shutdown ();
 
 #if DEBUG_IDISPOSABLE
-			Assert.Single (Responder.Instances);
-			Assert.True (Responder.Instances [0].WasDisposed);
+			Assert.Empty (Responder.Instances);
 #endif
 		}
 

--- a/UnitTests/TopLevels/MdiTests.cs
+++ b/UnitTests/TopLevels/MdiTests.cs
@@ -32,9 +32,7 @@ namespace Terminal.Gui.TopLevelTests {
 			Application.Shutdown ();
 
 #if DEBUG_IDISPOSABLE
-			Assert.Equal (2, Responder.Instances.Count);
-			Assert.True (Responder.Instances [0].WasDisposed);
-			Assert.True (Responder.Instances [1].WasDisposed);
+			Assert.Empty (Responder.Instances);
 #endif
 		}
 
@@ -49,9 +47,7 @@ namespace Terminal.Gui.TopLevelTests {
 
 			Application.Shutdown ();
 #if DEBUG_IDISPOSABLE
-			Assert.Equal (2, Responder.Instances.Count);
-			Assert.True (Responder.Instances [0].WasDisposed);
-			Assert.True (Responder.Instances [1].WasDisposed);
+			Assert.Empty (Responder.Instances);
 #endif
 		}
 


### PR DESCRIPTION
This fix only clear the `Instances` that were really disposed and fix the unit tests failure. On unit tests if `Instances` isn't empty at the end then a failure will be throw.